### PR TITLE
Update installation instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ This tap extracts:
 ## Installation
 
 ```bash
-pipx install tap-gorgias
+pipx install git+https://github.com/brooklyn-data/tap-gorgias.git
 ```
 
 ## Configuration


### PR DESCRIPTION
Updates the installations instructions since the current instructions won't work since tap-gorgias isn't on PyPl. Thank you to @NiallRees and Daniel Luftspring for helping me figure this out.