### PR TITLE
Add/event stream

### DIFF
--- a/tap_gorgias/schemas/events.json
+++ b/tap_gorgias/schemas/events.json
@@ -2,7 +2,7 @@
     "type": "object",
     "properties": {
         "id": {
-            "type": ["int", "null"],
+            "type": ["integer", "null"],
             "description": "The id of the event."
         },
         "context": {
@@ -19,7 +19,7 @@
             "description": "The data associated with the event."
         },
         "object_id": {
-            "type": ["int", "null"],
+            "type": ["integer", "null"],
             "description": "The event object id"
         },
         "object_type": {
@@ -31,7 +31,7 @@
             "description": "The type of event"
         },
         "user_id": {
-            "type": ["int", "null"],
+            "type": ["integer", "null"],
             "description": "ID of the user associated with the event"
         }
     }

--- a/tap_gorgias/schemas/events.json
+++ b/tap_gorgias/schemas/events.json
@@ -1,0 +1,40 @@
+{
+    "type": [
+      "object"
+    ],
+    "properties": {
+        "id": {
+            "type": ["int", "null"],
+            "description": "The id of the event."
+        },
+        "context": {
+            "type": ["string", "null"],
+            "description": "hash id."
+        },
+        "created_datetime": {
+            "type": ["string"],
+            "description": "The time the event was created",
+            "format": "date-time"
+        },
+        "data": {
+            "type": ["object", "null"],
+            "description": "The data associated with the event."
+        },
+        "object_id": {
+            "type": ["int", "null"],
+            "description": "The event object id"
+        },
+        "object_type": {
+            "type": ["string", "null"],
+            "description": "The type of object assocaited with the event"
+        },
+        "type": {
+            "type": ["string", "null"],
+            "description": "The type of event"
+        },
+        "user_id": {
+            "type": ["int", "null"],
+            "description": "ID of the user associated with the event"
+        }
+    }
+}

--- a/tap_gorgias/schemas/events.json
+++ b/tap_gorgias/schemas/events.json
@@ -1,7 +1,5 @@
 {
-    "type": [
-      "object"
-    ],
+    "type": "object",
     "properties": {
         "id": {
             "type": ["int", "null"],
@@ -12,12 +10,12 @@
             "description": "hash id."
         },
         "created_datetime": {
-            "type": ["string"],
+            "type": ["string", "null"],
             "description": "The time the event was created",
             "format": "date-time"
         },
         "data": {
-            "type": ["object", "null"],
+            "type": ["string", "null"],
             "description": "The data associated with the event."
         },
         "object_id": {

--- a/tap_gorgias/streams.py
+++ b/tap_gorgias/streams.py
@@ -648,6 +648,13 @@ class EventStream(GorgiasStream):
 
     schema_filepath = SCHEMAS_DIR / "events.json"
 
+    def post_process(self, row: dict, context: dict = None) -> dict:
+        if row:
+            data = row.get('data')
+            if data:
+                row['data'] = json.dumps(data)
+        return row
+
     def get_records(self, context: Optional[dict]) -> Iterable[Dict[str, Any]]:
         """Return a generator of row-type dictionary objects.
 

--- a/tap_gorgias/streams.py
+++ b/tap_gorgias/streams.py
@@ -648,6 +648,13 @@ class EventStream(GorgiasStream):
 
     schema_filepath = SCHEMAS_DIR / "events.json"
 
+    def get_url_params(
+        self, context: Optional[dict], next_page_token: Optional[Any]
+    ) -> Dict[str, Any]:
+        sync_start_datetime = self.get_starting_timestamp(context)
+        dt_str = sync_start_datetime.replace(tzinfo=None).isoformat()
+        return {"cursor": next_page_token, "limit": self.config["page_size"], "created_datetime[gte]":dt_str}
+
     def post_process(self, row: dict, context: dict = None) -> dict:
         if row:
             data = row.get('data')

--- a/tap_gorgias/streams.py
+++ b/tap_gorgias/streams.py
@@ -1,5 +1,6 @@
 """Stream type classes for tap-gorgias."""
 from urllib import parse
+from pathlib import Path
 from datetime import datetime
 import logging
 import json
@@ -20,6 +21,8 @@ CUSTOMER_SCHEMA = [
         th.Property("lastname", th.StringType),
     )
 ]
+
+SCHEMAS_DIR = Path(__file__).parent / Path("./schemas")
 
 class TicketsStream(GorgiasStream):
     """Define custom stream."""
@@ -632,3 +635,36 @@ class IntegreationsStream(GorgiasStream):
         th.Property("locked_datetime", th.DateTimeType),
         th.Property("deleted_datetime", th.DateTimeType),
     ).to_dict()
+
+class EventStream(GorgiasStream):
+    name = "events"
+    path = "/api/events"
+    primary_keys = ["id"]
+    replication_key = "created_datetime"
+    # is_sorted = True
+
+    # since next_page_token_jsonpath is already defined in GorgiasStream, no need to define it here 
+    # next_page_token_jsonpath = "$.meta.next_page"
+
+    schema_filepath = SCHEMAS_DIR / "events.json"
+
+    def get_records(self, context: Optional[dict]) -> Iterable[Dict[str, Any]]:
+        """Return a generator of row-type dictionary objects.
+
+        Each row emitted should be a dictionary of property names to their values.
+
+        Args:
+            context: Stream partition or context dictionary.
+
+        Yields:
+            One item per (possibly processed) record in the API.
+        """
+        sync_start_datetime = self.get_starting_timestamp(context)
+        logger.info(f"Starting timestamp: {sync_start_datetime}")
+        
+        for record in self.request_records(context):
+            transformed_record = self.post_process(record, context)
+            if transformed_record is None:
+                # Record filtered out during post_process()
+                continue
+            yield transformed_record

--- a/tap_gorgias/tap.py
+++ b/tap_gorgias/tap.py
@@ -12,6 +12,7 @@ from tap_gorgias.streams import (
     CustomersStream,
     TicketDetailsStream,
     IntegreationsStream,
+    EventStream
 )
 
 STREAM_TYPES = [
@@ -21,6 +22,7 @@ STREAM_TYPES = [
     CustomersStream,
     TicketDetailsStream,
     IntegreationsStream,
+    EventStream,
 ]
 
 


### PR DESCRIPTION
- in order to enforce incremental loads in the events stream, I have overridden an inherited method `get_url_params`, which allows me to add a filtering parameter specific to the events list endpoint that allows users to filter event by `created_datetime`